### PR TITLE
rpp-90304: Repair and update to current version of XCTest and Report Portal

### DIFF
--- a/Example/Example.xctestplan
+++ b/Example/Example.xctestplan
@@ -1,0 +1,35 @@
+{
+  "configurations" : [
+    {
+      "id" : "3BC8ABC9-D1EE-4E68-9E80-6999766F4B2E",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:ReportPortalAgent.xcodeproj",
+      "identifier" : "9203A38B2135C20C00BFAF82",
+      "name" : "Example"
+    }
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:ReportPortalAgent.xcodeproj",
+        "identifier" : "9203A3A92135C20E00BFAF82",
+        "name" : "ExampleUITests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:ReportPortalAgent.xcodeproj",
+        "identifier" : "9203A39E2135C20E00BFAF82",
+        "name" : "ExampleUnitTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/README.md
+++ b/README.md
@@ -21,7 +21,12 @@ pod install
 
 ## Report Portal properties
 
-Use info.plist file of your test target to specify properties of Report Portal:
+The properties for Report Portal configuration should be set in the `Info.plist` file of your Test Target. If you Test Target does't have an `Info.plist`, follow these steps to add:
+
+1. In your Test Target Folder, create a Property List named `Info.plist`.
+2. In Test Target Settings, configure 'Info.plist File' with the path `TestTargetFolderName/Info.plist`.
+
+Now, you can specify the Report Portal properties:
 
 * ReportPortalURL - URL to API of report portal (exaple https://report-portal.company.com/api/v1).
 * ReportPortalToken - token for authentication which you can get from RP account settings.
@@ -33,7 +38,11 @@ Use info.plist file of your test target to specify properties of Report Portal:
 * IsFinalTestBundle - use to mark last test target as YES, and all others as NO to allow single launch for them
 
 Example:
-![Alt text](https://github.com/Windmill-Smart-Solutions/ReportPortalAgent/blob/master/Screen%20Shot.png)
+![Alt text](./Screen%20Shot.png)
+
+## Important Notes
+
+Please be aware that this Report Portal agent is designed to work correctly only when tests are run sequentially. Parallel execution of tests is currently not supported.
 
 ## Authors
 

--- a/ReportPortalAgent.podspec
+++ b/ReportPortalAgent.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = '10.3'
     s.tvos.deployment_target = '10.3'
     s.swift_version = '4.1.2'
-    s.source_files = 'Sources/**/*'
+    s.source_files = 'Sources/**/*.swift'
 
     s.weak_framework = "XCTest"
     s.pod_target_xcconfig = {

--- a/ReportPortalAgent.xcodeproj/project.pbxproj
+++ b/ReportPortalAgent.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 		92FEE093212EEE2D00ADB1ED /* FinishItemEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinishItemEndPoint.swift; sourceTree = "<group>"; };
 		92FEE095212EF30700ADB1ED /* StartItemEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartItemEndPoint.swift; sourceTree = "<group>"; };
 		92FEE097212F028B00ADB1ED /* PostLogEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostLogEndPoint.swift; sourceTree = "<group>"; };
+		9497CEB02BC6C1BE00A23B73 /* Example.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = Example.xctestplan; sourceTree = "<group>"; };
 		B298DF4C300965F413082F68 /* Pods_RPAgentSwiftXCTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RPAgentSwiftXCTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -204,6 +205,7 @@
 		9203A38D2135C20C00BFAF82 /* Example */ = {
 			isa = PBXGroup;
 			children = (
+				9497CEB02BC6C1BE00A23B73 /* Example.xctestplan */,
 				9203A38E2135C20C00BFAF82 /* AppDelegate.swift */,
 				9203A3902135C20C00BFAF82 /* SummatorViewController.swift */,
 				9203A3BA2136B21F00BFAF82 /* SummatorService.swift */,

--- a/ReportPortalAgent.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/ReportPortalAgent.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9203A38B2135C20C00BFAF82"
+               BuildableName = "Example.app"
+               BlueprintName = "Example"
+               ReferencedContainer = "container:ReportPortalAgent.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:Example/Example.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9203A39E2135C20E00BFAF82"
+               BuildableName = "ExampleUnitTests.xctest"
+               BlueprintName = "ExampleUnitTests"
+               ReferencedContainer = "container:ReportPortalAgent.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9203A38B2135C20C00BFAF82"
+            BuildableName = "Example.app"
+            BlueprintName = "Example"
+            ReferencedContainer = "container:ReportPortalAgent.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9203A38B2135C20C00BFAF82"
+            BuildableName = "Example.app"
+            BlueprintName = "Example"
+            ReferencedContainer = "container:ReportPortalAgent.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sources/EndPoints/FinishItemEndPoint.swift
+++ b/Sources/EndPoints/FinishItemEndPoint.swift
@@ -21,7 +21,7 @@ struct FinishItemEndPoint: EndPoint {
       "launchUuid": launchID,
       "issue": [
         "comment": "",
-        "issue_type": status == .failed ? "TO_INVESTIGATE" : "NOT_ISSUE"
+        "issue_type": status == .failed ? "ti001" : "NOT_ISSUE"
       ],
       "status": status.rawValue
     ]

--- a/Sources/Entities/Launch.swift
+++ b/Sources/Entities/Launch.swift
@@ -8,6 +8,11 @@
 
 import Foundation
 
+struct FirstLaunch: Decodable  {
+    let id: String
+    let number: Int
+}
+
 struct Launch: Decodable  {
     let owner: String?
     let share: Bool?

--- a/Sources/RPListener.swift
+++ b/Sources/RPListener.swift
@@ -110,11 +110,7 @@ public class RPListener: NSObject, XCTestObservation {
       }
     }
   }
-  
-  public func testSuite(_ testSuite: XCTestSuite, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: Int) {
-    
-  }
-  
+
   public func testCaseWillStart(_ testCase: XCTestCase) {
     guard let reportingService = self.reportingService else { return }
 
@@ -126,19 +122,24 @@ public class RPListener: NSObject, XCTestObservation {
       }
     }
   }
-  
-  public func testCase(_ testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: Int) {
+
+  public func testCase(_ testCase: XCTestCase, didRecord issue: XCTIssueReference) {
     guard let reportingService = self.reportingService else { return }
-    
+
     queue.async {
       do {
-        try reportingService.reportError(message: "Test '\(String(describing: testCase.name)))' failed on line \(lineNumber), \(description)")
+        let lineNumberString = issue.sourceCodeContext.location?.lineNumber != nil
+          ? " on line \(issue.sourceCodeContext.location!.lineNumber)"
+          : ""
+        let errorMessage = "Test '\(String(describing: issue.description))' failed\(lineNumberString), \(issue.description)"
+
+        try reportingService.reportError(message: errorMessage)
       } catch let error {
         print(error)
       }
     }
   }
-  
+
   public func testCaseDidFinish(_ testCase: XCTestCase) {
     guard let reportingService = self.reportingService else { return }
 

--- a/Sources/ReportingService.swift
+++ b/Sources/ReportingService.swift
@@ -57,8 +57,8 @@ class ReportingService {
         )
         
         do {
-          try self.httpClient.callEndPoint(endPoint) { (result: Launch) in
-            self.launchID = String(result.id)
+          try self.httpClient.callEndPoint(endPoint) { (result: FirstLaunch) in
+            self.launchID = result.id
             self.semaphore.signal()
           }
         } catch let error {
@@ -179,7 +179,7 @@ class ReportingService {
       throw ReportingServiceError.launchIdNotFound
     }
     let endPoint = FinishLaunchEndPoint(launchID: launchID, status: launchStatus)
-    try httpClient.callEndPoint(endPoint) { (result: FinishLaunch) in
+    try httpClient.callEndPoint(endPoint) { (result: LaunchFinish) in
       self.semaphore.signal()
     }
     _ = semaphore.wait(timeout: .now() + timeOutForRequestExpectation)


### PR DESCRIPTION
- RPListener: Remove empty `testSuite(_ testSuite: XCTestSuite, didFailWithDescription ...)` as it is already deprecated
- RPListener: Replace depricated `testCase(_:didFailWithDescription:inFile:atLine:)` with `testCase(_:didRecord:)`
- Failed case now has "ti001" type instead of incorrect "TO_INVESTIGATE"
- Introduce **FirstLaunch** response model for "POST /launch" request
- Fix typo (FinishLaunch → LaunchFinish) 
- Migrate example tests to using Test plan
- Updated 'source_files' path in .podspec to only target Swift files in 'Sources' directory, excluding the Info.plist (resolves a duplication issue)
- Update README