### PR TITLE
Fix/decoding issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ cd <project>
 pod install
 ```
 
+Also available through SPM by name "agent-swift-xctest" or URL of current repo
+
 ## Report Portal properties
 
 The properties for Report Portal configuration should be set in the `Info.plist` file of your Test Target. If you Test Target does't have an `Info.plist`, follow these steps to add:
@@ -35,7 +37,7 @@ Now, you can specify the Report Portal properties:
 * ReportPortalURL - URL to API of report portal (exaple https://report-portal.company.com/api/v1).
 * ReportPortalToken - token for authentication which you can get from RP account settings.
 * ReportPortalLaunchName - name of launch.
-* Principal class - use ReportPortalAgent.RPListener from ReportPortalAgent lib. Also you can specify your own Observer which should conform to [XCTestObservation](https://developer.apple.com/documentation/xctest/xctestobservation) protocol.
+* Principal class - use ReportPortalAgent.RPListener from ReportPortalAgent lib for SPM or ReportPortal.RPListener for Cocoapods. Also you can specify your own Observer which should conform to [XCTestObservation](https://developer.apple.com/documentation/xctest/xctestobservation) protocol.
 * PushTestDataToReportPortal - can be used to switch off/on reporting
 * ReportPortalProjectName - project name from Report Portal
 * ReportPortalTags(optional) - can be used to specify tags, separated by comma.

--- a/Sources/EndPoints/FinishItemEndPoint.swift
+++ b/Sources/EndPoints/FinishItemEndPoint.swift
@@ -9,22 +9,26 @@
 import Foundation
 
 struct FinishItemEndPoint: EndPoint {
-
-  let method: HTTPMethod = .put
-  let relativePath: String
-  let parameters: [String : Any]
-
-  init(itemID: String, status: TestStatus, launchID: String) {
-    relativePath = "item/\(itemID)"
-    parameters = [
-      "end_time": TimeHelper.currentTimeAsString(),
-      "launchUuid": launchID,
-      "issue": [
-        "comment": "",
-        "issue_type": status == .failed ? "ti001" : "NOT_ISSUE"
-      ],
-      "status": status.rawValue
-    ]
-  }
-
+    
+    let method: HTTPMethod = .put
+    let relativePath: String
+    let parameters: [String : Any]
+    
+    init(itemID: String, status: TestStatus, launchID: String) throws {
+        guard itemID.isEmpty == false else {
+            throw ReportingServiceError.launchIdNotFound
+        }
+        
+        relativePath = "item/\(itemID)"
+        parameters = [
+            "end_time": TimeHelper.currentTimeAsString(),
+            "launchUuid": launchID,
+            "issue": [
+                "comment": "",
+                "issue_type": status == .failed ? "ti001" : "NOT_ISSUE"
+            ],
+            "status": status.rawValue
+        ]
+    }
+    
 }

--- a/Sources/Entities/Launch.swift
+++ b/Sources/Entities/Launch.swift
@@ -18,7 +18,8 @@ struct Launch: Decodable  {
     let share: Bool?
     let id: Int
     let uuid, name: String?
-    let number, startTime, endTime, lastModified: Int?
+    let number: Int?
+    let startTime, endTime, lastModified: String?
     let status: String?
     let statistics: Statistics?
     let attributes: [Attributes?]?

--- a/Sources/ReportingService.swift
+++ b/Sources/ReportingService.swift
@@ -140,7 +140,7 @@ public class ReportingService {
       launchStatus = .failed
     }
     
-      let endPoint = FinishItemEndPoint(itemID: testID, status: testStatus, launchID: self.launchID ?? "")
+      let endPoint = try FinishItemEndPoint(itemID: testID, status: testStatus, launchID: self.launchID ?? "")
     
     try httpClient.callEndPoint(endPoint) { (result: Finish) in
       self.semaphore.signal()
@@ -152,7 +152,7 @@ public class ReportingService {
     guard let testSuiteID = testSuiteID else {
       throw ReportingServiceError.testSuiteIdNotFound
     }
-    let endPoint = FinishItemEndPoint(itemID: testSuiteID, status: testSuiteStatus, launchID: self.launchID ?? "")
+    let endPoint = try FinishItemEndPoint(itemID: testSuiteID, status: testSuiteStatus, launchID: self.launchID ?? "")
     try httpClient.callEndPoint(endPoint) { (result: Finish) in
       self.semaphore.signal()
     }
@@ -163,7 +163,7 @@ public class ReportingService {
     guard let rootSuiteID = rootSuiteID else {
       throw ReportingServiceError.testSuiteIdNotFound
     }
-    let endPoint = FinishItemEndPoint(itemID: rootSuiteID, status: launchStatus, launchID: self.launchID ?? "")
+    let endPoint = try FinishItemEndPoint(itemID: rootSuiteID, status: launchStatus, launchID: self.launchID ?? "")
     try httpClient.callEndPoint(endPoint) { (result: Finish) in
       self.semaphore.signal()
     }


### PR DESCRIPTION
Fixed several issues:

1) wrong PrincipalClass configuration for using the agent via cocoapods - previously, the agent was not started at all when installing it via cocoapods if using the configuration as in the example
2) wrong decoding for dates at Launch object - wrong decoding for Launch object basically blocked execution and planned behavior
3) added an extra check for FinishItemEndPoint to contain a non-empty itemID, since itemID is a mandatory parameter - this silences the problem, but the actual problem still exists since "rootSuiteID" does not exist when it's required for startTestSuite and startTest - this is some problem at ReportingService which needs further deep debugging. 
