### PR TITLE
Fix attachement request

### DIFF
--- a/Sources/EndPoints/PostLogEndPoint.swift
+++ b/Sources/EndPoints/PostLogEndPoint.swift
@@ -33,7 +33,6 @@ struct PostLogEndPoint: EndPoint {
   // Enhanced initializer for logs with attachments (follows ReportPortal multipart spec)
   init(itemUuid: String, launchUuid: String, level: String, message: String, attachments: [FileAttachment] = []) {
     if !attachments.isEmpty {
-      // Create the log entry structure exactly as Java client does
       var logEntry: [String: Any] = [
         "item_id": itemUuid,
         "launch_id": launchUuid,
@@ -42,7 +41,6 @@ struct PostLogEndPoint: EndPoint {
         "level": level
       ]
       
-      // Add file reference if attachment exists (matches working example)
       if let firstAttachment = attachments.first {
         logEntry["file"] = [
           "name": firstAttachment.filename

--- a/Sources/EndPoints/PostLogEndPoint.swift
+++ b/Sources/EndPoints/PostLogEndPoint.swift
@@ -33,8 +33,7 @@ struct PostLogEndPoint: EndPoint {
   // Enhanced initializer for logs with attachments (follows ReportPortal multipart spec)
   init(itemUuid: String, launchUuid: String, level: String, message: String, attachments: [FileAttachment] = []) {
     if !attachments.isEmpty {
-      
-      // The server explicitly requires a part named 'json_request_part' containing the log metadata.
+      // Create the log entry structure exactly as Java client does
       let logEntry: [String: Any] = [
         "item_id": itemUuid,
         "launch_id": launchUuid,
@@ -43,17 +42,18 @@ struct PostLogEndPoint: EndPoint {
         "level": level
       ]
       
-      // The server expects an ARRAY of log entries for the 'json_request_part'
+      // CRITICAL: Java client sends json_request_part as an ARRAY of log entries
+      // This matches the server's expectation for multipart log requests
       parameters = [
-        "json_request_part": [logEntry]
+        "json_request_part": [logEntry]  // Array containing single log entry
       ]
     } else {
-      // For simple JSON requests, use flat structure with original field names
+      // For simple JSON requests, use flat structure
       parameters = [
         "item_id": itemUuid,
         "level": level,
         "message": message,
-        "time": TimeHelper.currentTimeAsString()  // Use string format for simple requests
+        "time": TimeHelper.currentTimeAsString()
       ]
     }
     

--- a/Sources/EndPoints/PostLogEndPoint.swift
+++ b/Sources/EndPoints/PostLogEndPoint.swift
@@ -49,10 +49,8 @@ struct PostLogEndPoint: EndPoint {
         ]
       }
       
-      // CRITICAL: Java client sends json_request_part as an ARRAY of log entries
-      // This matches the server's expectation for multipart log requests
       parameters = [
-        "json_request_part": [logEntry]  // Array containing single log entry
+        "json_request_part": [logEntry]
       ]
     } else {
       parameters = [

--- a/Sources/EndPoints/PostLogEndPoint.swift
+++ b/Sources/EndPoints/PostLogEndPoint.swift
@@ -35,8 +35,8 @@ struct PostLogEndPoint: EndPoint {
     if !attachments.isEmpty {
       // Create the log entry structure exactly as Java client does
       var logEntry: [String: Any] = [
-        "itemUuid": itemUuid,      // EXACT field name from working Java example
-        "launchUuid": launchUuid,  // EXACT field name from working Java example
+        "item_id": itemUuid,
+        "launch_id": launchUuid,
         "time": TimeHelper.currentTimeAsString(),
         "message": message,
         "level": level
@@ -45,7 +45,7 @@ struct PostLogEndPoint: EndPoint {
       // Add file reference if attachment exists (matches working example)
       if let firstAttachment = attachments.first {
         logEntry["file"] = [
-          "name": firstAttachment.filename  // matches: "file":{"name":"ee390d92-9794-4a7f-b288-66cb5c7d3269"}
+          "name": firstAttachment.filename
         ]
       }
       
@@ -55,23 +55,20 @@ struct PostLogEndPoint: EndPoint {
         "json_request_part": [logEntry]  // Array containing single log entry
       ]
     } else {
-      // For simple JSON requests, use flat structure
       parameters = [
-        "itemUuid": itemUuid,      // Use consistent field names
-        "launchUuid": launchUuid,  // Use consistent field names
+        "item_id": itemUuid,
         "level": level,
         "message": message,
         "time": TimeHelper.currentTimeAsString()
       ]
     }
     
-    // Map attachments to use binary_part field name (matches working Java example)
     self.attachments = attachments.map { attachment in
       FileAttachment(
         data: attachment.data,
         filename: attachment.filename,
         mimeType: attachment.mimeType,
-        fieldName: "binary_part"  // EXACT field name from working example
+        fieldName: "binary_part"
       )
     }
   }

--- a/Sources/ReportingService.swift
+++ b/Sources/ReportingService.swift
@@ -172,17 +172,24 @@ public class ReportingService {
       return
     }
     
+    print("📸 ReportingService Debug: Attempting to capture screenshot for test ID: \(testID)")
+    
     let errorSemaphore = DispatchSemaphore(value: 0)
     
     var attachments: [FileAttachment] = []
     
-    // Capture screenshot if possible
-    if let screenshotData = captureScreenshot(testCase: testCase) {
+    // Capture screenshot with proper format handling
+    if let screenshotResult = captureScreenshot(testCase: testCase) {
       // Use safe filename with only digits and underscores to avoid JSON parsing issues
       let timestamp = String(Int64(Date().timeIntervalSince1970 * 1000))
-      let filename = "error_screenshot_\(timestamp).jpg"
-      let attachment = FileAttachment(data: screenshotData, filename: filename, mimeType: "image/jpeg")
+      let filename = "error_screenshot_\(timestamp).\(screenshotResult.fileExtension)"
+      let attachment = FileAttachment(data: screenshotResult.data, filename: filename, mimeType: screenshotResult.mimeType)
       attachments.append(attachment)
+      
+      print("📸 ReportingService Debug: Screenshot captured successfully!")
+      print("   • Format: \(screenshotResult.mimeType)")
+      print("   • Size: \(formatBytes(screenshotResult.data.count))")
+      print("   • Filename: \(filename)")
     } else {
       print("⚠️ ReportingService Screenshot Warning: Failed to capture screenshot for error: '\(message)'")
     }
@@ -198,7 +205,11 @@ public class ReportingService {
       attachments: attachments
     )
     
+    print("📤 ReportingService Debug: Sending log with \(attachments.count) attachment(s)")
+    
     try httpClient.callEndPoint(endPoint) { (result: LogResponse) in
+      print("✅ ReportingService Debug: Log API responded with success")
+      print("   • Response: \(result)")
       errorSemaphore.signal()
     }
     
@@ -307,37 +318,45 @@ private extension ReportingService {
   }
     
     // MARK: - Screenshot Capture
-    func captureScreenshot(testCase: XCTestCase?) -> Data? {
+    func captureScreenshot(testCase: XCTestCase?) -> (data: Data, fileExtension: String, mimeType: String)? {
 #if canImport(XCTest) && canImport(UIKit)
         // Direct screenshot capture using XCUIScreen
         let screenshot = XCUIScreen.main.screenshot()
         let originalData = screenshot.pngRepresentation
         
-        // Convert to UIImage for PNG compression via resizing
+        // Convert to UIImage for format processing
         guard let uiImage = UIImage(data: originalData) else {
-            return originalData
+            return nil
         }
         
         // Smart compression strategy: JPEG works better than PNG for screenshots
         var bestData = originalData
+        var isJpeg = false
         
         // Try JPEG compression first (much more effective for screenshots)
         if let jpegData = uiImage.jpegData(compressionQuality: 0.7) {
             if jpegData.count < originalData.count {
                 bestData = jpegData
+                isJpeg = true
             }
         }
         
-        // If still too large, try lower quality
-        if bestData.count > 100 * 1024 { // Still over 100KB
+        // If still too large, try lower quality JPEG
+        if bestData.count > 100 * 1024 && !isJpeg { // Still over 100KB and not using JPEG yet
             if let jpegData = uiImage.jpegData(compressionQuality: 0.5) {
                 if jpegData.count < bestData.count {
                     bestData = jpegData
+                    isJpeg = true
                 }
             }
         }
         
-        return bestData
+        // Return appropriate format information based on what we're actually sending
+        if isJpeg {
+            return (bestData, "jpg", "image/jpeg")
+        } else {
+            return (bestData, "png", "image/png")
+        }
 #else
         print("🚨 ReportingService Platform Error: Screenshot capture not available on this platform. Only iOS supports screenshot capture.")
         return nil

--- a/Sources/ReportingService.swift
+++ b/Sources/ReportingService.swift
@@ -185,11 +185,6 @@ public class ReportingService {
       let filename = "error_screenshot_\(timestamp).\(screenshotResult.fileExtension)"
       let attachment = FileAttachment(data: screenshotResult.data, filename: filename, mimeType: screenshotResult.mimeType)
       attachments.append(attachment)
-      
-      print("📸 ReportingService Debug: Screenshot captured successfully!")
-      print("   • Format: \(screenshotResult.mimeType)")
-      print("   • Size: \(formatBytes(screenshotResult.data.count))")
-      print("   • Filename: \(filename)")
     } else {
       print("⚠️ ReportingService Screenshot Warning: Failed to capture screenshot for error: '\(message)'")
     }

--- a/Sources/Utilities/HTTPClient.swift
+++ b/Sources/Utilities/HTTPClient.swift
@@ -146,8 +146,6 @@ class HTTPClient: NSObject, URLSessionDelegate {
 
     let lineBreak = "\r\n"
 
-    body.append("\r\n".data(using: .utf8)!)
-
     // Helper to append string
     func append(_ string: String) {
       if let data = string.data(using: .utf8) {
@@ -155,7 +153,7 @@ class HTTPClient: NSObject, URLSessionDelegate {
       }
     }
 
-    // 1. Append parameters
+    // 1. Append parameters (each parameter as separate multipart section)
     for (key, value) in parameters {
       append("--\(boundary)\r\n")
 
@@ -164,7 +162,7 @@ class HTTPClient: NSObject, URLSessionDelegate {
         append(stringValue)
         append(lineBreak)
       } else if JSONSerialization.isValidJSONObject(value) {
-        // Treat any collection value as JSON
+        // Handle JSON objects/arrays - critical for json_request_part
         append("Content-Disposition: form-data; name=\"\(key)\"\r\n")
         append("Content-Type: application/json\r\n\r\n")
         if let jsonData = try? JSONSerialization.data(withJSONObject: value, options: []) {
@@ -192,7 +190,7 @@ class HTTPClient: NSObject, URLSessionDelegate {
       append(lineBreak)
     }
 
-    // 3. Close the body
+    // 3. Close the body with final boundary
     append("--\(boundary)--\r\n")
 
     return body


### PR DESCRIPTION
### **The Documentation Gap**
The ReportPortal documentation fails to clearly explain that when you send file attachments:
The JSON log entry must contain a file reference pointing to the attachment filename
The multipart part containing the file must be named binary_part (not file)
The filename in binary_part must match the file.name in the JSON
This creates a critical linking mechanism between the JSON log entry and the binary attachment that the documentation doesn't explain properly.

**Why This Was So Confusing**
Your implementation was getting 201 success responses because:
The multipart structure was technically correct
The server accepted the request
But ReportPortal couldn't link the attachment to the log entry without the file reference
The documentation makes it seem like you just need to send the JSON and the attachment separately, but there's actually a hidden linking mechanism via the file.name reference that connects them.
What We Fixed
Apply to ReportingSer...
// Before: No file reference (following incomplete docs)
let logEntry = [
  "itemUuid": itemUuid,
  "message": message,
  "level": level
]

// After: Proper file reference (following working examples)
var logEntry = [
  "itemUuid": itemUuid, 
  "message": message,
  "level": level
]
if let attachment = attachments.first {
  logEntry["file"] = ["name": attachment.filename]  // Critical missing piece!
}
The lesson here is that the official documentation is incomplete and we need to to reverse-engineer working client implementations to understand the full picture.
