### PR TITLE
Add Support for XCTest_Gherkin Library to be able to report results into ReportPortal

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "ReportPortalAgent",
+//            dependencies: [],
             path: ".",
             sources: ["Sources"]),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,6 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "ReportPortalAgent",
-//            dependencies: [],
             path: ".",
             sources: ["Sources"]),
     ]

--- a/Sources/RPListener.swift
+++ b/Sources/RPListener.swift
@@ -212,14 +212,16 @@ open class RPListener: NSObject, XCTestObservation {
 #if os(macOS)
     // macOS API
     public func testCase(_ testCase: XCTestCase, didRecord issue: XCTIssueReference) {
-        let lineNumberString = issue.sourceCodeContext.location?.lineNumber.map { " on line \($0)" } ?? ""
+        let lineNumberString = (issue.sourceCodeContext.location?.lineNumber)
+            .map { " on line \($0)" } ?? ""
         let errorMessage = "Test '\(testCase.name)' failed\(lineNumberString): \(issue.description)"
         reportFailure(testCase: testCase, message: errorMessage)
     }
 #else
     // API for iOS, iPadOS, tvOS, visionOS, watchOS
     public func testCase(_ testCase: XCTestCase, didRecord issue: XCTIssue) {
-        let lineNumberString = issue.sourceCodeContext.location?.lineNumber.map { " on line \($0)" } ?? ""
+        let lineNumberString = (issue.sourceCodeContext.location?.lineNumber)
+            .map { " on line \($0)" } ?? ""
         let errorMessage = "Test '\(testCase.name)' failed\(lineNumberString), \(issue.description)"
         reportFailure(testCase: testCase, message: errorMessage)
     }

--- a/Sources/RPListener.swift
+++ b/Sources/RPListener.swift
@@ -282,8 +282,8 @@ open class RPListener: NSObject, XCTestObservation {
             let selector = invocation.selector
             let featureScenarioDataSelector = NSSelectorFromString("featureScenarioData:")
 
-            if nativeTestCaseClass.responds(to: featureScenarioDataSelector),
-               let unmanagedResult = (nativeTestCaseClass as AnyObject).perform(featureScenarioDataSelector, with: selector as Any) {
+            if (nativeTestCaseClass as AnyObject).responds(to: featureScenarioDataSelector),
+                let unmanagedResult = (nativeTestCaseClass as AnyObject).perform(featureScenarioDataSelector, with: selector as Any) {
                 let tupleAny = unmanagedResult.takeRetainedValue()
                 if let tuple = tupleAny as? (Any, Any) {
                     let featureName = (tuple.0 as? NSObject)?.value(forKey: "name") as? String

--- a/Sources/RPListener.swift
+++ b/Sources/RPListener.swift
@@ -192,7 +192,6 @@ open class RPListener: NSObject, XCTestObservation {
     /// This helper manually initializes suites if IDs are missing, ensuring
     /// proper ReportPortal hierarchy for Gherkin scenarios.
     private func ensureGherkinSuitesInitialized(for testCase: XCTestCase) {
-        private func ensureGherkinSuitesInitialized(for testCase: XCTestCase) {
         // Only apply this workaround when XCTest-Gherkin is present
         guard NSClassFromString("NativeTestCase") != nil || NSClassFromString("XCGNativeInitializer") != nil else { return }
         guard let reportingService = reportingService,
@@ -212,19 +211,11 @@ open class RPListener: NSObject, XCTestObservation {
 
     // Modern API (iOS 17+, Xcode 15+)
     public func testCase(_ testCase: XCTestCase, didRecord issue: XCTIssue) {
-        guard let reportingService = reportingService else { return }
-
-        queue.async {
-            do {
-                let lineNumberString = issue.sourceCodeContext.location?.lineNumber != nil
-                    ? " on line \(issue.sourceCodeContext.location!.lineNumber)"
-                    : ""
-                let errorMessage = "Test '\(testCase.name)' failed\(lineNumberString), \(issue.description)"
-                reportFailure(testCase: testCase, message: errorMessage)
-            } catch {
-                print("🚨 RPListener Issue Reporting Error: \(error.localizedDescription)")
-            }
-        }
+        let lineNumberString = issue.sourceCodeContext.location?.lineNumber != nil
+            ? " on line \(issue.sourceCodeContext.location!.lineNumber)"
+            : ""
+        let errorMessage = "Test '\(testCase.name)' failed\(lineNumberString), \(issue.description)"
+        reportFailure(testCase: testCase, message: errorMessage)
     }
 
     // Legacy API (pre-iOS 17, Xcode <15)
@@ -307,7 +298,7 @@ open class RPListener: NSObject, XCTestObservation {
 
             if (nativeTestCaseClass as AnyObject).responds(to: featureScenarioDataSelector),
                 let unmanagedResult = (nativeTestCaseClass as AnyObject).perform(featureScenarioDataSelector, with: selector as Any) {
-                let tupleAny = unmanagedResult.takeUnRetainedValue()
+                let tupleAny = unmanagedResult.takeUnretainedValue()
                 if let tuple = tupleAny as? (Any, Any) {
                     let featureName = (tuple.0 as? NSObject)?.value(forKey: "name") as? String
                     let scenarioName = (tuple.1 as? NSObject)?.value(forKey: "name") as? String

--- a/Sources/RPListener.swift
+++ b/Sources/RPListener.swift
@@ -209,6 +209,7 @@ open class RPListener: NSObject, XCTestObservation {
         }
     }
 
+#if swift(>=5.9) // Swift 5.9 is shipped with Xcode 15 / iOS 17 SDK
     // Modern API (iOS 17+, Xcode 15+)
     @available(iOS 17.0, macOS 14.0, *)
     public func testCase(_ testCase: XCTestCase, didRecord issue: XCTIssue) {
@@ -218,22 +219,24 @@ open class RPListener: NSObject, XCTestObservation {
         let errorMessage = "Test '\(testCase.name)' failed\(lineNumberString), \(issue.description)"
         reportFailure(testCase: testCase, message: errorMessage)
     }
-
+#else
     // Legacy API (pre-iOS 17, Xcode <15)
     public func testCase(_ testCase: XCTestCase, didRecord issue: XCTIssueReference) {
         let lineNumberString = issue.sourceCodeContext.location?.lineNumber != nil
             ? " on line \(issue.sourceCodeContext.location!.lineNumber)"
             : ""
         let errorMessage = "Test '\(testCase.name)' failed\(lineNumberString): \(issue.description)"
-        
         reportFailure(testCase: testCase, message: errorMessage)
     }
+#endif
 
-    // Legacy API (pre-iOS 17, Xcode < 15)
-    public func testCase(_ testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: Int) {
+    // Legacy API (very old XCTest)
+    public func testCase(_ testCase: XCTestCase,
+                         didFailWithDescription description: String,
+                         inFile filePath: String?,
+                         atLine lineNumber: Int) {
         let fileInfo = filePath != nil ? " in \(URL(fileURLWithPath: filePath!).lastPathComponent)" : ""
         let errorMessage = "Test failed on line \(lineNumber)\(fileInfo): \(description)"
-        
         reportFailure(testCase: testCase, message: errorMessage)
     }
 

--- a/Sources/RPListener.swift
+++ b/Sources/RPListener.swift
@@ -190,16 +190,17 @@ open class RPListener: NSObject, XCTestObservation {
     /// This helper manually initializes suites if IDs are missing, ensuring
     /// proper ReportPortal hierarchy for Gherkin scenarios.
     private func ensureGherkinSuitesInitialized(for testCase: XCTestCase) {
-        guard reportingService?.rootSuiteID == nil || reportingService?.testSuiteID == nil else { return }
+        guard let reportingService = reportingService, reportingService.rootSuiteID == nil || reportingService.testSuiteID == nil else { return }
         
         print("🛠 RPListener: Initializing missing Gherkin suites for ReportPortal.")
-        
-        if reportingService?.rootSuiteID == nil {
-            try? reportingService?.startRootSuite(XCTestSuite(name: "Gherkin Features"))
-        }
-        if reportingService?.testSuiteID == nil {
-            let suiteName = String(describing: type(of: testCase))
-            try? reportingService?.startTestSuite(XCTestSuite(name: suiteName))
+        queue.sync {
+            if reportingService?.rootSuiteID == nil {
+                try? reportingService?.startRootSuite(XCTestSuite(name: "Gherkin Features"))
+            }
+            if reportingService?.testSuiteID == nil {
+                let suiteName = String(describing: type(of: testCase))
+                try? reportingService?.startTestSuite(XCTestSuite(name: suiteName))
+            }
         }
     }
 

--- a/Sources/RPListener.swift
+++ b/Sources/RPListener.swift
@@ -210,6 +210,7 @@ open class RPListener: NSObject, XCTestObservation {
     }
 
     // Modern API (iOS 17+, Xcode 15+)
+    @available(iOS 17.0, macOS 14.0, *)
     public func testCase(_ testCase: XCTestCase, didRecord issue: XCTIssue) {
         let lineNumberString = issue.sourceCodeContext.location?.lineNumber != nil
             ? " on line \(issue.sourceCodeContext.location!.lineNumber)"

--- a/Sources/RPListener.swift
+++ b/Sources/RPListener.swift
@@ -204,6 +204,24 @@ open class RPListener: NSObject, XCTestObservation {
         }
     }
 
+    // Modern API (iOS 17+, Xcode 15+)
+    public func testCase(_ testCase: XCTestCase, didRecord issue: XCTIssue) {
+        guard let reportingService = reportingService else { return }
+
+        queue.async {
+            do {
+                let lineNumberString = issue.sourceCodeContext.location?.lineNumber != nil
+                    ? " on line \(issue.sourceCodeContext.location!.lineNumber)"
+                    : ""
+                let errorMessage = "Test '\(issue.description)' failed\(lineNumberString), \(issue.description)"
+                try reportingService.reportErrorWithScreenshot(message: errorMessage, testCase: testCase)
+            } catch {
+                print("🚨 RPListener Issue Reporting Error: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    // Legacy API (pre-iOS 17, Xcode <15)
     public func testCase(_ testCase: XCTestCase, didRecord issue: XCTIssueReference) {
         guard let reportingService = reportingService else { return }
 

--- a/Sources/RPListener.swift
+++ b/Sources/RPListener.swift
@@ -193,7 +193,6 @@ open class RPListener: NSObject, XCTestObservation {
     /// proper ReportPortal hierarchy for Gherkin scenarios.
     private func ensureGherkinSuitesInitialized(for testCase: XCTestCase) {
         private func ensureGherkinSuitesInitialized(for testCase: XCTestCase) {
-        guard let reportingService = reportingService, reportingService.rootSuiteID == nil || reportingService.testSuiteID == nil else { return }
         // Only apply this workaround when XCTest-Gherkin is present
         guard NSClassFromString("NativeTestCase") != nil || NSClassFromString("XCGNativeInitializer") != nil else { return }
         guard let reportingService = reportingService,

--- a/Sources/RPListener.swift
+++ b/Sources/RPListener.swift
@@ -124,6 +124,8 @@ open class RPListener: NSObject, XCTestObservation {
         
         queue.async {
             do {
+                // Ensure launch is started before starting suites (idempotent)
+                try reportingService.startLaunch()
                 if testSuite.name.contains(".xctest") {
                     try reportingService.startRootSuite(testSuite)
                 } else {
@@ -301,7 +303,7 @@ open class RPListener: NSObject, XCTestObservation {
 
             if (nativeTestCaseClass as AnyObject).responds(to: featureScenarioDataSelector),
                 let unmanagedResult = (nativeTestCaseClass as AnyObject).perform(featureScenarioDataSelector, with: selector as Any) {
-                let tupleAny = unmanagedResult.takeRetainedValue()
+                let tupleAny = unmanagedResult.takeUnRetainedValue()
                 if let tuple = tupleAny as? (Any, Any) {
                     let featureName = (tuple.0 as? NSObject)?.value(forKey: "name") as? String
                     let scenarioName = (tuple.1 as? NSObject)?.value(forKey: "name") as? String

--- a/Sources/RPListener.swift
+++ b/Sources/RPListener.swift
@@ -4,7 +4,6 @@
 //
 //  Created by Windmill Smart Solutions on 5/12/17.
 //  Enhanced for Gherkin integration without hard dependency
-//  Copyright © 2017 Oxagile. All rights reserved.
 //
 
 import Foundation
@@ -12,125 +11,132 @@ import XCTest
 
 open class RPListener: NSObject, XCTestObservation {
   
-  public static let shared = RPListener()
+    // MARK: - Singleton
+    public static let shared = RPListener()
 
-  public var reportingService: ReportingService?
-  private let queue = DispatchQueue(label: "com.report_portal.reporting", qos: .utility)
+    public var reportingService: ReportingService?
+    private let queue = DispatchQueue(label: "com.report_portal.reporting", qos: .utility)
 
-  private override init() {
-    super.init()
-    XCTestObservationCenter.shared.addTestObserver(self)
-  }
+    private override init() {
+        super.init()
+        XCTestObservationCenter.shared.addTestObserver(self)
+    }
+    
+    /// Explicit bootstrap for test targets (call once early in test lifecycle)
+    @discardableResult
+    public static func register() -> RPListener {
+        return RPListener.shared
+    }
   
-  private func readConfiguration(from testBundle: Bundle) -> AgentConfiguration {
-    guard
-      let bundlePath = testBundle.path(forResource: "RPConfig", ofType: "plist"),
-      let bundleProperties = NSDictionary(contentsOfFile: bundlePath) as? [String: Any],
-      let portalPath = bundleProperties["ReportPortalURL"] as? String,
-      let portalURL = URL(string: portalPath),
-      let projectName = bundleProperties["ReportPortalProjectName"] as? String,
-      let token = bundleProperties["ReportPortalToken"] as? String,
-      let shouldFinishLaunch = bundleProperties["IsFinalTestBundle"] as? Bool,
-      let launchName = bundleProperties["ReportPortalLaunchName"] as? String else
-    {
-      fatalError("Configure properties for report portal in the Info.plist")
-    }
-    
-    let shouldReport: Bool
-    if let pushTestDataString = bundleProperties["PushTestDataToReportPortal"] as? String {
-        shouldReport = Bool(pushTestDataString.lowercased()) ?? false
-    } else if let pushTestDataBool = bundleProperties["PushTestDataToReportPortal"] as? Bool {
-        shouldReport = pushTestDataBool
-    } else {
-        fatalError("PushTestDataToReportPortal must be either a string or a boolean in the Info.plist")
-    }
-    
-    var tags: [String] = []
-    if let tagString = bundleProperties["ReportPortalTags"] as? String {
-      tags = tagString.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
-        .components(separatedBy: ",")
-        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-        .filter { !$0.isEmpty }
-    }
-    var launchMode: LaunchMode = .default
-    if let isDebug = bundleProperties["IsDebugLaunchMode"] as? Bool, isDebug == true {
-      launchMode = .debug
-    }
-
-    var testNameRules: NameRules = []
-    if let rules = bundleProperties["TestNameRules"] as? [String: Bool] {
-      if rules["StripTestPrefix"] == true {
-        testNameRules.update(with: .stripTestPrefix)
-      }
-      if rules["WhiteSpaceOnUnderscore"] == true {
-        testNameRules.update(with: .whiteSpaceOnUnderscore)
-      }
-      if rules["WhiteSpaceOnCamelCase"] == true {
-        testNameRules.update(with: .whiteSpaceOnCamelCase)
-      }
-    }
-    
-    return AgentConfiguration(
-      reportPortalURL: portalURL,
-      projectName: projectName,
-      launchName: launchName,
-      shouldSendReport: shouldReport,
-      portalToken: token,
-      tags: tags,
-      shouldFinishLaunch: shouldFinishLaunch,
-      launchMode: launchMode,
-      testNameRules: testNameRules
-    )
-  }
-  
-  public func testBundleWillStart(_ testBundle: Bundle) {
-    let configuration = readConfiguration(from: testBundle)
-    
-    guard configuration.shouldSendReport else {
-      print("Set 'YES' for 'PushTestDataToReportPortal' property in Info.plist if you want to put data to report portal")
-      return
-    }
-    
-    let reportingService = ReportingService(configuration: configuration, testBundle: testBundle)
-    self.reportingService = reportingService
-    
-    queue.async {
-      do {
-        try reportingService.startLaunch()
-      } catch let error {
-        print("🚨 RPListener Launch Start Error: Failed to start ReportPortal launch for test bundle. This will prevent all test results from being reported. Error details: \(error.localizedDescription)")
-      }
-    }
-  }
-  
-  public func testSuiteWillStart(_ testSuite: XCTestSuite) {
-    guard let reportingService = self.reportingService else {
-      print("🚨 RPListener Configuration Error: ReportingService is not available. Test suite '\(testSuite.name)' will not be reported to ReportPortal.")
-      return
-    }
-    
-    guard
-      !testSuite.name.contains("All tests"),
-      !testSuite.name.contains("Selected tests") else
-    {
-      return
-    }
-    
-    queue.async {
-      do {
-        if testSuite.name.contains(".xctest") {
-          try reportingService.startRootSuite(testSuite)
-        } else {
-          try reportingService.startTestSuite(testSuite)
+    // MARK: - Configuration
+    private func readConfiguration(from testBundle: Bundle) -> AgentConfiguration {
+        guard
+            let bundlePath = testBundle.path(forResource: "RPConfig", ofType: "plist"),
+            let bundleProperties = NSDictionary(contentsOfFile: bundlePath) as? [String: Any],
+            let portalPath = bundleProperties["ReportPortalURL"] as? String,
+            let portalURL = URL(string: portalPath),
+            let projectName = bundleProperties["ReportPortalProjectName"] as? String,
+            let token = bundleProperties["ReportPortalToken"] as? String,
+            let shouldFinishLaunch = bundleProperties["IsFinalTestBundle"] as? Bool,
+            let launchName = bundleProperties["ReportPortalLaunchName"] as? String else {
+                fatalError("Configure properties for report portal in the RPConfig.plist")
         }
-      } catch let error {
-        print("🚨 RPListener Suite Start Error: Failed to start test suite '\(testSuite.name)' in ReportPortal. Error details: \(error.localizedDescription)")
-      }
+        
+        let shouldReport: Bool
+        if let pushTestDataString = bundleProperties["PushTestDataToReportPortal"] as? String {
+            shouldReport = Bool(pushTestDataString.lowercased()) ?? false
+        } else if let pushTestDataBool = bundleProperties["PushTestDataToReportPortal"] as? Bool {
+            shouldReport = pushTestDataBool
+        } else {
+            fatalError("PushTestDataToReportPortal must be either a string or a boolean in the RPConfig.plist")
+        }
+        
+        var tags: [String] = []
+        if let tagString = bundleProperties["ReportPortalTags"] as? String {
+            tags = tagString.trimmingCharacters(in: .whitespacesAndNewlines)
+                .components(separatedBy: ",")
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+        }
+        var launchMode: LaunchMode = .default
+        if let isDebug = bundleProperties["IsDebugLaunchMode"] as? Bool, isDebug == true {
+            launchMode = .debug
+        }
+
+        var testNameRules: NameRules = []
+        if let rules = bundleProperties["TestNameRules"] as? [String: Bool] {
+            if rules["StripTestPrefix"] == true {
+                testNameRules.update(with: .stripTestPrefix)
+            }
+            if rules["WhiteSpaceOnUnderscore"] == true {
+                testNameRules.update(with: .whiteSpaceOnUnderscore)
+            }
+            if rules["WhiteSpaceOnCamelCase"] == true {
+                testNameRules.update(with: .whiteSpaceOnCamelCase)
+            }
+        }
+        
+        return AgentConfiguration(
+            reportPortalURL: portalURL,
+            projectName: projectName,
+            launchName: launchName,
+            shouldSendReport: shouldReport,
+            portalToken: token,
+            tags: tags,
+            shouldFinishLaunch: shouldFinishLaunch,
+            launchMode: launchMode,
+            testNameRules: testNameRules
+        )
     }
-  }
+  
+    // MARK: - XCTestObservation
+  
+    public func testBundleWillStart(_ testBundle: Bundle) {
+        let configuration = readConfiguration(from: testBundle)
+        
+        guard configuration.shouldSendReport else {
+            print("Set 'YES' for 'PushTestDataToReportPortal' in RPConfig.plist to enable reporting.")
+            return
+        }
+        
+        let reportingService = ReportingService(configuration: configuration, testBundle: testBundle)
+        self.reportingService = reportingService
+        
+        queue.async {
+            do {
+                try reportingService.startLaunch()
+            } catch {
+                print("🚨 RPListener Launch Start Error: \(error.localizedDescription)")
+            }
+        }
+    }
+  
+    public func testSuiteWillStart(_ testSuite: XCTestSuite) {
+        guard let reportingService = reportingService else {
+            print("🚨 RPListener: ReportingService missing. Suite '\(testSuite.name)' not reported.")
+            return
+        }
+        
+        guard !testSuite.name.contains("All tests"),
+              !testSuite.name.contains("Selected tests") else {
+            return
+        }
+        
+        queue.async {
+            do {
+                if testSuite.name.contains(".xctest") {
+                    try reportingService.startRootSuite(testSuite)
+                } else {
+                    try reportingService.startTestSuite(testSuite)
+                }
+            } catch {
+                print("🚨 RPListener Suite Start Error: \(error.localizedDescription)")
+            }
+        }
+    }
 
     public func testCaseWillStart(_ testCase: XCTestCase) {
-        // If no reportingService yet, bootstrap it synchronously
+        // Bootstrap reportingService if needed
         if reportingService == nil {
             let configBundle = Bundle(for: type(of: testCase))
             let configuration = readConfiguration(from: configBundle)
@@ -143,11 +149,19 @@ open class RPListener: NSObject, XCTestObservation {
             let service = ReportingService(configuration: configuration, testBundle: configBundle)
             self.reportingService = service
 
-            // Synchronous launch start to ensure launchID is ready before startTest
             do {
-                try service.startLaunch()
+                try service.startLaunch() // sync launch start
             } catch {
                 print("🚨 RPListener: Failed to start launch for \(testCase.name) — \(error.localizedDescription)")
+            }
+        }
+
+        // Ensure launch is ready even if async start from testBundleWillStart hasn't finished
+        if reportingService?.launchID == nil {
+            do {
+                try reportingService?.startLaunch()
+            } catch {
+                print("🚨 RPListener: Failed to ensure launch started — \(error.localizedDescription)")
             }
         }
 
@@ -162,13 +176,7 @@ open class RPListener: NSObject, XCTestObservation {
 
         // Ensure test suite is started
         if reportingService?.testSuiteID == nil {
-            let suiteName: String
-            if let nativeClass = NSClassFromString("NativeTestCase"),
-               testCase.isKind(of: nativeClass) {
-                suiteName = String(describing: type(of: testCase))
-            } else {
-                suiteName = "Default Suite"
-            }
+            let suiteName = String(describing: type(of: testCase))
             do {
                 try reportingService?.startTestSuite(XCTestSuite(name: suiteName))
             } catch {
@@ -176,32 +184,8 @@ open class RPListener: NSObject, XCTestObservation {
             }
         }
 
-        // Extract feature/scenario names dynamically
-        var featureName: String? = nil
-        var scenarioName: String? = nil
-        if let nativeTestCaseClass = NSClassFromString("NativeTestCase"),
-           testCase.isKind(of: nativeTestCaseClass),
-           let invocation = testCase.invocation {
-
-            let selector = invocation.selector
-            let featureScenarioDataSelector = NSSelectorFromString("featureScenarioData:")
-
-            if nativeTestCaseClass.responds(to: featureScenarioDataSelector),
-               let unmanagedResult = (nativeTestCaseClass as AnyObject).perform(featureScenarioDataSelector, with: selector as Any) {
-
-                let tupleAny = unmanagedResult.takeUnretainedValue()
-                if let tuple = tupleAny as? (Any, Any) {
-                    if let featureObj = tuple.0 as? NSObject,
-                       let fname = featureObj.value(forKey: "name") as? String {
-                        featureName = fname
-                    }
-                    if let scenarioObj = tuple.1 as? NSObject,
-                       let sname = scenarioObj.value(forKey: "name") as? String {
-                        scenarioName = sname
-                    }
-                }
-            }
-        }
+        // Unified Gherkin name extraction
+        let (featureName, scenarioName) = extractGherkinNames(from: testCase)
 
         // Start the test
         do {
@@ -211,122 +195,125 @@ open class RPListener: NSObject, XCTestObservation {
         }
     }
 
-  @available(*, deprecated, message: "Use func testCase(_ testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: Int) for iOS 17+")
-  public func testCase(_ testCase: XCTestCase, didRecord issue: XCTIssueReference) {
-    guard let reportingService = self.reportingService else {
-      print("🚨 RPListener Configuration Error: ReportingService is not available. Test issue for '\(testCase.name)' will not be reported to ReportPortal.")
-      return
-    }
-
-    queue.async {
-      do {
-        let lineNumberString = issue.sourceCodeContext.location?.lineNumber != nil
-          ? " on line \(issue.sourceCodeContext.location!.lineNumber)"
-          : ""
-        let errorMessage = "Test '\(String(describing: issue.description))' failed\(lineNumberString), \(issue.description)"
-
-        try reportingService.reportErrorWithScreenshot(message: errorMessage, testCase: testCase)
-      } catch let error {
-        print("🚨 RPListener Issue Reporting Error: Failed to report test issue for '\(testCase.name)' to ReportPortal. Error details: \(error.localizedDescription)")
-      }
-    }
-  }
-
-  // For iOS 17+
-  public func testCase(_ testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: Int) {
-    guard let reportingService = self.reportingService else {
-      print("🚨 RPListener Configuration Error: ReportingService is not available. Test failure for '\(testCase.name)' will not be reported to ReportPortal.")
-      return
-    }
-
-    queue.async {
-      do {
-        let fileInfo = filePath != nil ? " in \(URL(fileURLWithPath: filePath!).lastPathComponent)" : ""
-        let errorMessage = "Test failed on line \(lineNumber)\(fileInfo): \(description)"
-        
-        try reportingService.reportErrorWithScreenshot(message: errorMessage, testCase: testCase)
-      } catch let error {
-        print("🚨 RPListener Failure Reporting Error: Failed to report test failure for '\(testCase.name)' to ReportPortal. Error details: \(error.localizedDescription)")
-      }
-    }
-  }
-  
-  public func testCaseDidFinish(_ testCase: XCTestCase) {
-    guard let reportingService = self.reportingService else {
-      print("🚨 RPListener Configuration Error: ReportingService is not available. Test completion for '\(testCase.name)' will not be reported to ReportPortal.")
-      return
-    }
-
-    queue.async {
-      do {
-        try reportingService.finishTest(testCase)
-      } catch let error {
-        print("🚨 RPListener Test Finish Error: Failed to finish test case '\(testCase.name)' in ReportPortal. Error details: \(error.localizedDescription)")
-      }
-    }
-  }
-  
-  public func testSuiteDidFinish(_ testSuite: XCTestSuite) {
-    guard let reportingService = self.reportingService else {
-      print("🚨 RPListener Configuration Error: ReportingService is not available. Test suite completion for '\(testSuite.name)' will not be reported to ReportPortal.")
-      return
-    }
-    
-    guard
-      !testSuite.name.contains("All tests"),
-      !testSuite.name.contains("Selected tests") else
-    {
-      return
-    }
-    
-    queue.async {
-      do {
-        if testSuite.name.contains(".xctest") {
-          try reportingService.finishRootSuite()
-        } else {
-          try reportingService.finishTestSuite()
+    @available(*, deprecated, message: "Use didFailWithDescription for iOS 17+")
+    public func testCase(_ testCase: XCTestCase, didRecord issue: XCTIssueReference) {
+        guard let reportingService = reportingService else {
+            print("🚨 RPListener: ReportingService missing. Issue for '\(testCase.name)' not reported.")
+            return
         }
-      } catch let error {
-        print("🚨 RPListener Suite Finish Error: Failed to finish test suite '\(testSuite.name)' in ReportPortal. Error details: \(error.localizedDescription)")
-      }
+
+        queue.async {
+            do {
+                let lineNumberString = issue.sourceCodeContext.location?.lineNumber != nil
+                    ? " on line \(issue.sourceCodeContext.location!.lineNumber)"
+                    : ""
+                let errorMessage = "Test '\(issue.description)' failed\(lineNumberString), \(issue.description)"
+                try reportingService.reportErrorWithScreenshot(message: errorMessage, testCase: testCase)
+            } catch {
+                print("🚨 RPListener Issue Reporting Error: \(error.localizedDescription)")
+            }
+        }
     }
-  }
+
+    public func testCase(_ testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: Int) {
+        guard let reportingService = reportingService else {
+            print("🚨 RPListener: ReportingService missing. Failure for '\(testCase.name)' not reported.")
+            return
+        }
+
+        queue.async {
+            do {
+                let fileInfo = filePath != nil ? " in \(URL(fileURLWithPath: filePath!).lastPathComponent)" : ""
+                let errorMessage = "Test failed on line \(lineNumber)\(fileInfo): \(description)"
+                try reportingService.reportErrorWithScreenshot(message: errorMessage, testCase: testCase)
+            } catch {
+                print("🚨 RPListener Failure Reporting Error: \(error.localizedDescription)")
+            }
+        }
+    }
   
-  public func testBundleDidFinish(_ testBundle: Bundle) {
-    guard let reportingService = self.reportingService else {
-      print("🚨 RPListener Configuration Error: ReportingService is not available. Test bundle completion will not be reported to ReportPortal.")
-      return
+    public func testCaseDidFinish(_ testCase: XCTestCase) {
+        guard let reportingService = reportingService else { return }
+
+        queue.async {
+            do {
+                try reportingService.finishTest(testCase)
+            } catch {
+                print("🚨 RPListener Test Finish Error: \(error.localizedDescription)")
+            }
+        }
+    }
+  
+    public func testSuiteDidFinish(_ testSuite: XCTestSuite) {
+        guard let reportingService = reportingService else { return }
+        
+        guard !testSuite.name.contains("All tests"),
+              !testSuite.name.contains("Selected tests") else {
+            return
+        }
+        
+        queue.async {
+            do {
+                if testSuite.name.contains(".xctest") {
+                    try reportingService.finishRootSuite()
+                } else {
+                    try reportingService.finishTestSuite()
+                }
+            } catch {
+                print("🚨 RPListener Suite Finish Error: \(error.localizedDescription)")
+            }
+        }
+    }
+  
+    public func testBundleDidFinish(_ testBundle: Bundle) {
+        guard let reportingService = reportingService else { return }
+
+        queue.sync {
+            do {
+                try reportingService.finishLaunch()
+            } catch {
+                print("🚨 RPListener Launch Finish Error: \(error.localizedDescription)")
+            }
+        }
     }
 
-    queue.sync {
-      do {
-        try reportingService.finishLaunch()
-      } catch let error {
-        print("🚨 RPListener Launch Finish Error: Failed to finish ReportPortal launch for test bundle. Error details: \(error.localizedDescription)")
-      }
-    }
-  }
+    // MARK: - Gherkin Detection & Name Extraction
+    private func extractGherkinNames(from testCase: XCTestCase) -> (feature: String?, scenario: String?) {
+        if let nativeTestCaseClass = NSClassFromString("NativeTestCase"),
+           testCase.isKind(of: nativeTestCaseClass),
+           let invocation = testCase.invocation {
 
-  // MARK: - Gherkin Detection & Name Extraction (No hard dependency)
-  private func extractGherkinNames(from testCase: XCTestCase) -> (feature: String?, scenario: String?) {
-    if let gherkinBaseClass = NSClassFromString("XCGNativeInitializer"),
-       testCase.isKind(of: gherkinBaseClass) {
-      
-      let featureName = String(describing: type(of: testCase))
-      let scenarioName = parseScenarioName(from: testCase.name)
-      return (featureName, scenarioName)
-    }
-    return (nil, nil)
-  }
+            let selector = invocation.selector
+            let featureScenarioDataSelector = NSSelectorFromString("featureScenarioData:")
 
-  private func parseScenarioName(from rawName: String) -> String {
-    // rawName example: "-[MyFeatureTests testScenario_1]"
-    guard let methodPart = rawName.split(separator: " ").last else { return rawName }
-    var cleaned = methodPart.replacingOccurrences(of: "]", with: "")
-    if cleaned.hasPrefix("test") {
-      cleaned.removeFirst("test".count)
+            if nativeTestCaseClass.responds(to: featureScenarioDataSelector),
+               let unmanagedResult = (nativeTestCaseClass as AnyObject).perform(featureScenarioDataSelector, with: selector as Any) {
+                let tupleAny = unmanagedResult.takeUnretainedValue()
+                if let tuple = tupleAny as? (Any, Any) {
+                    let featureName = (tuple.0 as? NSObject)?.value(forKey: "name") as? String
+                    let scenarioName = (tuple.1 as? NSObject)?.value(forKey: "name") as? String
+                    return (featureName, scenarioName)
+                }
+            }
+        }
+
+        if let gherkinBaseClass = NSClassFromString("XCGNativeInitializer"),
+           testCase.isKind(of: gherkinBaseClass) {
+            let featureName = String(describing: type(of: testCase))
+            let scenarioName = parseScenarioName(from: testCase.name)
+            return (featureName, scenarioName)
+        }
+
+        return (nil, nil)
     }
-    cleaned = cleaned.replacingOccurrences(of: "_", with: " ")
-    return cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
-  }
+
+    private func parseScenarioName(from rawName: String) -> String {
+        guard let methodPart = rawName.split(separator: " ").last else { return rawName }
+        var cleaned = methodPart.replacingOccurrences(of: "]", with: "")
+        if cleaned.hasPrefix("test") {
+            cleaned.removeFirst("test".count)
+        }
+        cleaned = cleaned.replacingOccurrences(of: "_", with: " ")
+        return cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
 }

--- a/Sources/RPListener.swift
+++ b/Sources/RPListener.swift
@@ -194,17 +194,16 @@ open class RPListener: NSObject, XCTestObservation {
         
         print("🛠 RPListener: Initializing missing Gherkin suites for ReportPortal.")
         queue.sync {
-            if reportingService?.rootSuiteID == nil {
-                try? reportingService?.startRootSuite(XCTestSuite(name: "Gherkin Features"))
+            if reportingService.rootSuiteID == nil {
+                try? reportingService.startRootSuite(XCTestSuite(name: "Gherkin Features"))
             }
-            if reportingService?.testSuiteID == nil {
+            if reportingService.testSuiteID == nil {
                 let suiteName = String(describing: type(of: testCase))
-                try? reportingService?.startTestSuite(XCTestSuite(name: suiteName))
+                try? reportingService.startTestSuite(XCTestSuite(name: suiteName))
             }
         }
     }
 
-    @available(*, deprecated, message: "Use didFailWithDescription for iOS 17+")
     public func testCase(_ testCase: XCTestCase, didRecord issue: XCTIssueReference) {
         guard let reportingService = reportingService else { return }
 

--- a/Sources/RPListener.swift
+++ b/Sources/RPListener.swift
@@ -208,24 +208,19 @@ open class RPListener: NSObject, XCTestObservation {
             }
         }
     }
-
-#if swift(>=5.9) // Swift 5.9 is shipped with Xcode 15 / iOS 17 SDK
-    // Modern API (iOS 17+, Xcode 15+)
-    @available(iOS 17.0, macOS 14.0, *)
-    public func testCase(_ testCase: XCTestCase, didRecord issue: XCTIssue) {
-        let lineNumberString = issue.sourceCodeContext.location?.lineNumber != nil
-            ? " on line \(issue.sourceCodeContext.location!.lineNumber)"
-            : ""
-        let errorMessage = "Test '\(testCase.name)' failed\(lineNumberString), \(issue.description)"
+    
+#if os(macOS)
+    // macOS API
+    public func testCase(_ testCase: XCTestCase, didRecord issue: XCTIssueReference) {
+        let lineNumberString = issue.sourceCodeContext.location?.lineNumber.map { " on line \($0)" } ?? ""
+        let errorMessage = "Test '\(testCase.name)' failed\(lineNumberString): \(issue.description)"
         reportFailure(testCase: testCase, message: errorMessage)
     }
 #else
-    // Legacy API (pre-iOS 17, Xcode <15)
-    public func testCase(_ testCase: XCTestCase, didRecord issue: XCTIssueReference) {
-        let lineNumberString = issue.sourceCodeContext.location?.lineNumber != nil
-            ? " on line \(issue.sourceCodeContext.location!.lineNumber)"
-            : ""
-        let errorMessage = "Test '\(testCase.name)' failed\(lineNumberString): \(issue.description)"
+    // API for iOS, iPadOS, tvOS, visionOS, watchOS
+    public func testCase(_ testCase: XCTestCase, didRecord issue: XCTIssue) {
+        let lineNumberString = issue.sourceCodeContext.location?.lineNumber.map { " on line \($0)" } ?? ""
+        let errorMessage = "Test '\(testCase.name)' failed\(lineNumberString), \(issue.description)"
         reportFailure(testCase: testCase, message: errorMessage)
     }
 #endif

--- a/Sources/ReportingService.swift
+++ b/Sources/ReportingService.swift
@@ -42,7 +42,7 @@ public final class ReportingService {
   private let configuration: AgentConfiguration
   private var testBundle: Bundle?
   
-  private var launchID: String?
+  var launchID: String?
   private var testSuiteStatus = TestStatus.passed
   private var launchStatus = TestStatus.passed
   var rootSuiteID: String?


### PR DESCRIPTION
Add Support for XCTest_Gherkin Library to be able to report results into ReportPortal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Public bootstrap/register entry point and shared listener for centralized lifecycle control.
  - Public test logging with levels (info/warn/error/debug) and optional attachments.
  - startTest accepts optional feature/scenario names and includes Gherkin-friendly naming support.

- Improvements
  - More resilient test lifecycle handling and consolidated failure reporting.
  - Safer exposure of internal state with controlled read access.

- Breaking Changes
  - Direct public initialization removed — use the new bootstrap/register flow.
  - Configuration now read from RPConfig.plist instead of Info.plist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->